### PR TITLE
Fix a build error and a warning

### DIFF
--- a/src/opencl.c
+++ b/src/opencl.c
@@ -2,6 +2,7 @@
 
 #define CL_TARGET_OPENCL_VERSION 220
 #ifdef __APPLE__
+#define clCreateCommandQueueWithProperties clCreateCommandQueue
 #include <OpenCL/cl.h>
 #else
 #include <CL/cl.h>
@@ -196,7 +197,7 @@ int opencl_init(struct backend *bnd, const int platform_id,
       calloc(1, sizeof(struct opencl_backend));
   ocl->device_id = device;
   ocl->ctx = clCreateContext(NULL, 1, &device, NULL, NULL, &err);
-  ocl->queue = clCreateCommandQueueWithProperties(ocl->ctx, device, NULL, &err);
+  ocl->queue = clCreateCommandQueueWithProperties(ocl->ctx, device, 0, &err);
 
   free(cl_devices);
   free(cl_platforms);


### PR DESCRIPTION
Currently, `libnomp` builds fine with changes from this PR on macOS with M1 chip. But tests fail (200 - 230).