### PR TITLE
Support `@ref` as a click-able link

### DIFF
--- a/docs/user-api.rst
+++ b/docs/user-api.rst
@@ -32,6 +32,8 @@ Defines argument type.
    :project: libnomp
    :content-only:
 
+.. _group__nomp__errors:
+
 Errors
 ^^^^^^
 .. doxygengroup:: nomp_errors


### PR DESCRIPTION
Addresses following suggestion.

> @HirumalPriyashan : Do you know how to make this `@ref` a click-able link? Right now, it just shows the name of the group. It would be nice if we can just click on it and it will take us to the relevant docs in the documentation.

_Originally posted by @thilinarmtb in https://github.com/nomp-org/libnomp/pull/25#discussion_r973770484_