### PR TITLE
Install docs to the target

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -32,3 +32,5 @@ add_custom_target(Sphinx ALL
                   ${SPHINX_SOURCE} ${SPHINX_BUILD}
                   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                   COMMENT "Generating documentation with Sphinx")
+
+install(DIRECTORY ${SPHINX_BUILD}/ DESTINATION ${CMAKE_INSTALL_PREFIX}/docs)


### PR DESCRIPTION
Docs are installed with `make install` target. 

Resolve: https://github.com/nomp-org/libnomp/issues/45