### PR TITLE
Fix invalid parameter passing for nomp_init

### DIFF
--- a/tests/nomp-api-000.c
+++ b/tests/nomp-api-000.c
@@ -11,9 +11,9 @@ int main(int argc, char *argv[]) {
   nomp_assert(err == NOMP_NOT_INITIALIZED_ERROR);
 
   // Calling `nomp_init` twice must return an error, but must not segfault
-  err = nomp_init(backend, device, platform);
+  err = nomp_init(backend, platform, device);
   nomp_chk(err);
-  err = nomp_init(backend, device, platform);
+  err = nomp_init(backend, platform, device);
   nomp_assert(err == NOMP_INITIALIZED_ERROR);
 
   // Calling `nomp_finalize` twice must return an error, but must not segfault

--- a/tests/nomp-api-100.c
+++ b/tests/nomp-api-100.c
@@ -10,7 +10,7 @@ int main(int argc, char *argv[]) {
   int device = argc > 2 ? atoi(argv[2]) : 0;
   int platform = argc > 3 ? atoi(argv[3]) : 0;
 
-  int err = nomp_init(backend, device, platform);
+  int err = nomp_init(backend, platform, device);
   nomp_chk(err);
 
   nomp_api_100_int(0, 10);

--- a/tests/nomp-api-110-impl.h
+++ b/tests/nomp-api-110-impl.h
@@ -7,7 +7,7 @@ int nomp_api_110(const char *backend, int device, int platform, unsigned s,
 
   TEST_TYPE a[10] = {0}, b[10] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
 
-  int err = nomp_init(backend, device, platform);
+  int err = nomp_init(backend, platform, device);
   nomp_chk(err);
 
   // Free'ing before mapping should return an error

--- a/tests/nomp-api-200.c
+++ b/tests/nomp-api-200.c
@@ -10,7 +10,7 @@ int main(int argc, char *argv[]) {
   int device = argc > 2 ? atoi(argv[2]) : 0;
   int platform = argc > 3 ? atoi(argv[3]) : 0;
 
-  int err = nomp_init(backend, device, platform);
+  int err = nomp_init(backend, platform, device);
   nomp_chk(err);
 
   nomp_api_200_int();

--- a/tests/nomp-api-210.c
+++ b/tests/nomp-api-210.c
@@ -10,7 +10,7 @@ int main(int argc, char *argv[]) {
   int device = argc > 2 ? atoi(argv[2]) : 0;
   int platform = argc > 3 ? atoi(argv[3]) : 0;
 
-  int err = nomp_init(backend, device, platform);
+  int err = nomp_init(backend, platform, device);
   nomp_chk(err);
 
   nomp_api_210_int();

--- a/tests/nomp-api-220.c
+++ b/tests/nomp-api-220.c
@@ -10,7 +10,7 @@ int main(int argc, char *argv[]) {
   int device = argc > 2 ? atoi(argv[2]) : 0;
   int platform = argc > 3 ? atoi(argv[3]) : 0;
 
-  int err = nomp_init(backend, device, platform);
+  int err = nomp_init(backend, platform, device);
   nomp_chk(err);
 
   nomp_api_220_int();

--- a/tests/nomp-api-221.c
+++ b/tests/nomp-api-221.c
@@ -10,7 +10,7 @@ int main(int argc, char *argv[]) {
   int device = argc > 2 ? atoi(argv[2]) : 0;
   int platform = argc > 3 ? atoi(argv[3]) : 0;
 
-  int err = nomp_init(backend, device, platform);
+  int err = nomp_init(backend, platform, device);
   nomp_chk(err);
 
   nomp_api_221_int();

--- a/tests/nomp-api-222.c
+++ b/tests/nomp-api-222.c
@@ -46,7 +46,7 @@ int main(int argc, char *argv[]) {
   int device = argc > 2 ? atoi(argv[2]) : 0;
   int platform = argc > 3 ? atoi(argv[3]) : 0;
 
-  int err = nomp_init(backend, device, platform);
+  int err = nomp_init(backend, platform, device);
   nomp_chk(err);
 
   nomp_api_222_int();

--- a/tests/nomp-api-230-impl.h
+++ b/tests/nomp-api-230-impl.h
@@ -30,7 +30,7 @@ int nomp_api_230_aux(TEST_TYPE *a, TEST_TYPE *b, TEST_TYPE *c, int N) {
 
 #define nomp_api_230 TOKEN_PASTE(nomp_api_230, TEST_SUFFIX)
 int nomp_api_230(const char *backend, int device, int platform) {
-  int err = nomp_init(backend, device, platform);
+  int err = nomp_init(backend, platform, device);
   nomp_chk(err);
 
   int n = 10;

--- a/tests/nomp-api-231-impl.h
+++ b/tests/nomp-api-231-impl.h
@@ -30,7 +30,7 @@ int nomp_api_231_aux(TEST_TYPE *a, TEST_TYPE *b, TEST_TYPE *c, int N) {
 
 #define nomp_api_231 TOKEN_PASTE(nomp_api_231, TEST_SUFFIX)
 int nomp_api_231(const char *backend, int device, int platform) {
-  int err = nomp_init(backend, device, platform);
+  int err = nomp_init(backend, platform, device);
   nomp_chk(err);
 
   int n = 10;

--- a/tests/nomp-api-232-impl.h
+++ b/tests/nomp-api-232-impl.h
@@ -30,7 +30,7 @@ int nomp_api_232_aux(TEST_TYPE *a, TEST_TYPE *b, TEST_TYPE *c, int N) {
 
 #define nomp_api_232 TOKEN_PASTE(nomp_api_232, TEST_SUFFIX)
 int nomp_api_232(const char *backend, int device, int platform) {
-  int err = nomp_init(backend, device, platform);
+  int err = nomp_init(backend, platform, device);
   nomp_chk(err);
 
   int n = 10;

--- a/tests/nomp-api-233-impl.h
+++ b/tests/nomp-api-233-impl.h
@@ -30,7 +30,7 @@ int nomp_api_233_aux(TEST_TYPE *a, TEST_TYPE *b, TEST_TYPE *c, int N) {
 
 #define nomp_api_233 TOKEN_PASTE(nomp_api_233, TEST_SUFFIX)
 int nomp_api_233(const char *backend, int device, int platform) {
-  int err = nomp_init(backend, device, platform);
+  int err = nomp_init(backend, platform, device);
   nomp_chk(err);
 
   int n = 10;

--- a/tests/nomp-api-240.c
+++ b/tests/nomp-api-240.c
@@ -10,7 +10,7 @@ int main(int argc, char *argv[]) {
   int device = argc > 2 ? atoi(argv[2]) : 0;
   int platform = argc > 3 ? atoi(argv[3]) : 0;
 
-  int err = nomp_init(backend, device, platform);
+  int err = nomp_init(backend, platform, device);
   nomp_chk(err);
 
   nomp_api_240_int(10);


### PR DESCRIPTION
While the public API of `nomp_init` requires the parameters in the order of `nomp_init(const char *backend, int platform, int device)`, all the test cases have swapped the parameters between `platform` and `device`.