### PR TITLE
Update transforms for ISPC

### DIFF
--- a/python/kernel_wrappers.py
+++ b/python/kernel_wrappers.py
@@ -103,6 +103,8 @@ class ISPCKernelWrapper(BaseKernelWrapper):
                 )
             ),
         )
+        index = device_code.find("task")
+        device_code = device_code[index:]
         return combine([device_code, wrapper])
 
 

--- a/tests/nomp-api-200.py
+++ b/tests/nomp-api-200.py
@@ -6,8 +6,10 @@ LOOPY_LANG_VERSION = (2018, 2)
 def transform(knl, context):
     (iname,) = knl.default_entrypoint.all_inames()
     i_inner, i_outer = f"{iname}_inner", f"{iname}_outer"
+    backend = context["backend"]
+    split_size = 8 if (backend == "ispc") else 32
     knl = lp.split_iname(
-        knl, iname, 32, inner_iname=i_inner, outer_iname=i_outer
+        knl, iname, split_size, inner_iname=i_inner, outer_iname=i_outer
     )
     knl = lp.tag_inames(knl, {i_outer: "g.0", i_inner: "l.0"})
     return knl

--- a/tests/nomp-api-205.py
+++ b/tests/nomp-api-205.py
@@ -6,8 +6,10 @@ LOOPY_LANG_VERSION = (2018, 2)
 def transform(knl, context):
     (iname,) = knl.default_entrypoint.all_inames()
     i_inner, i_outer = f"{iname}_inner", f"{iname}_outer"
+    backend = context["backend"]
+    split_size = 8 if (backend == "ispc") else 32
     knl = lp.split_iname(
-        knl, iname, 32, inner_iname=i_inner, outer_iname=i_outer
+        knl, iname, split_size, inner_iname=i_inner, outer_iname=i_outer
     )
     knl = lp.tag_inames(knl, {i_outer: "g.0", i_inner: "l.0"})
     return knl

--- a/tests/nomp-api-210.py
+++ b/tests/nomp-api-210.py
@@ -6,8 +6,10 @@ LOOPY_LANG_VERSION = (2018, 2)
 def transform(knl, context):
     (iname,) = knl.default_entrypoint.all_inames()
     i_inner, i_outer = f"{iname}_inner", f"{iname}_outer"
+    backend = context["backend"]
+    split_size = 8 if (backend == "ispc") else 32
     knl = lp.split_iname(
-        knl, iname, 32, inner_iname=i_inner, outer_iname=i_outer
+        knl, iname, split_size, inner_iname=i_inner, outer_iname=i_outer
     )
     knl = lp.tag_inames(knl, {i_outer: "g.0", i_inner: "l.0"})
     return knl

--- a/tests/nomp-api-215.py
+++ b/tests/nomp-api-215.py
@@ -4,8 +4,10 @@ LOOPY_LANG_VERSION = (2018, 2)
 
 
 def transform(knl, context):
+    backend = context["backend"]
+    split_size = 8 if (backend == "ispc") else 32
     knl = lp.split_iname(
-        knl, "i", 32, inner_iname="i_inner", outer_iname="i_outer"
+        knl, "i", split_size, inner_iname="i_inner", outer_iname="i_outer"
     )
     knl = lp.tag_inames(knl, {"i_outer": "g.0", "i_inner": "l.0", "j": "for"})
     return knl

--- a/tests/nomp-api-240.py
+++ b/tests/nomp-api-240.py
@@ -4,6 +4,8 @@ LOOPY_LANG_VERSION = (2018, 2)
 
 
 def transform(knl, context):
-    knl = lp.split_iname(knl, "i", 32)
+    backend = context["backend"]
+    split_size = 8 if (backend == "ispc") else 32
+    knl = lp.split_iname(knl, "i", split_size)
     knl = lp.tag_inames(knl, {"i_outer": "g.0", "i_inner": "l.0", "j": "for"})
     return knl

--- a/tests/nomp-api-300.py
+++ b/tests/nomp-api-300.py
@@ -4,12 +4,17 @@ LOOPY_LANG_VERSION = (2018, 2)
 
 
 def transform(knl, context):
+    backend = context["backend"]
     def split_and_tag(knl, i, axis):
+        split_size = 8 if (backend == "ispc") else 32
         i_inner, i_outer = f"{i}_inner", f"{i}_outer"
         knl = lp.split_iname(
-            knl, i, 32, inner_iname=i_inner, outer_iname=i_outer
+            knl, i, split_size, inner_iname=i_inner, outer_iname=i_outer
         )
-        knl = lp.tag_inames(knl, {i_outer: f"g.{axis}", i_inner: f"l.{axis}"})
+        if (backend == "ispc" and axis >= 1):
+            knl = lp.tag_inames(knl, {i_outer: f"g.{axis}"})
+        else:
+            knl = lp.tag_inames(knl, {i_outer: f"g.{axis}", i_inner: f"l.{axis}"})
         return knl
 
     (i, j) = knl.default_entrypoint.all_inames()
@@ -20,23 +25,27 @@ def transform(knl, context):
 
 
 def mxm_transform(knl, context):
-    knl = lp.split_iname(knl, "i", 32)
-    knl = lp.split_iname(knl, "j", 32)
-
-    knl = lp.tag_inames(
-        knl,
-        {
+    backend = context["backend"]
+    split_size = 8 if (backend == "ispc") else 32
+    knl = lp.split_iname(knl, "i", split_size)
+    knl = lp.split_iname(knl, "j", split_size)
+    iname_to_tag = {
             "i_outer": "g.0",
             "i_inner": "l.0",
             "j_outer": "g.1",
-            "j_inner": "l.1",
             "k": "for",
-        },
+        }
+    if (backend != "ispc"): iname_to_tag["j_inner"] = "l.1"
+    knl = lp.tag_inames(
+        knl,
+        iname_to_tag,
     )
     return knl
 
 
 def vxm_transform(knl, context):
-    knl = lp.split_iname(knl, "i", 32)
+    backend = context["backend"]
+    split_size = 8 if (backend == "ispc") else 32
+    knl = lp.split_iname(knl, "i", split_size)
     knl = lp.tag_inames(knl, {"i_outer": "g.0", "i_inner": "l.0", "j": "for"})
     return knl

--- a/tests/nomp-api-350.py
+++ b/tests/nomp-api-350.py
@@ -4,6 +4,8 @@ LOOPY_LANG_VERSION = (2018, 2)
 
 
 def transform(knl, context):
-    knl = lp.split_iname(knl, "i", 32)
+    backend = context["backend"]
+    split_size = 8 if (backend == "ispc") else 32
+    knl = lp.split_iname(knl, "i", split_size)
     knl = lp.tag_inames(knl, {"i_outer": "g.0", "i_inner": "l.0", "j": "for"})
     return knl


### PR DESCRIPTION
Currently all the tests for ISPC backend passes except for 

- nomp-api-050 - due to the use of same memory locations
- nomp-api-350 - kernel produced by loopy fails to compile
- nomp-api-500 - includes reductions

![image](https://github.com/nomp-org/libnomp/assets/57571152/da999a71-a0ff-4d50-9df6-15f202c735ef)

This PR also removes unused macros produced for device code by loopy which causes compilation issues.