### PR TITLE
Use NOMP_CUDA and NOMP_HIP to distinguish CUDA/HIP

### DIFF
--- a/backends/cuda.c
+++ b/backends/cuda.c
@@ -4,6 +4,7 @@
 
 static const char *ERR_STR_BACKEND_FAILURE = "CUDA %s failure: %s.";
 #define NOMP_BACKEND_FAILURE NOMP_CUDA_FAILURE
+#define NOMP_CUDA 1
 
 #define DRIVER cuda
 #define RUNTIME_COMPILATION nvrtc
@@ -50,4 +51,5 @@ static const char *ERR_STR_BACKEND_FAILURE = "CUDA %s failure: %s.";
 #undef RUNTIME_COMPILATION
 #undef DRIVER
 
+#undef NOMP_CUDA
 #undef NOMP_BACKEND_FAILURE

--- a/backends/hip.c
+++ b/backends/hip.c
@@ -3,6 +3,7 @@
 
 static const char *ERR_STR_BACKEND_FAILURE = "HIP %s failure: %s.";
 #define NOMP_BACKEND_FAILURE NOMP_HIP_FAILURE
+#define NOMP_HIP 1
 
 #define DRIVER hip
 #define RUNTIME_COMPILATION hiprtc
@@ -40,4 +41,5 @@ static const char *ERR_STR_BACKEND_FAILURE = "HIP %s failure: %s.";
 #undef RUNTIME_COMPILATION
 #undef DRIVER
 
+#undef NOMP_HIP
 #undef NOMP_BACKEND_FAILURE

--- a/backends/unified-cuda-hip-impl.h
+++ b/backends/unified-cuda-hip-impl.h
@@ -206,15 +206,10 @@ static int backend_device_query(struct nomp_backend_t *bnd, int device_id) {
 
   set_string_aux("device::name", prop.name);
 
-#if defined(__HIP_PLATFORM_HCC__)
+#if defined(NOMP_HIP)
   set_string_aux("device::vendor", "AMD");
-  set_string_aux("device::type", "gpu");
-#elif defined(__HIP_PLATFORM_NVCC__) || defined(checkk_cu)
+#elif defined(NOMP_CUDA)
   set_string_aux("device::vendor", "NVIDIA");
-  set_string_aux("device::type", "gpu");
-#else
-  set_string_aux("device::vendor", "unknown");
-  set_string_aux("device::type", "unknown");
 #endif
 
 #define set_int_aux(KEY, VAL)                                                  \
@@ -227,6 +222,8 @@ static int backend_device_query(struct nomp_backend_t *bnd, int device_id) {
   int driver_version;
   backendDriverGetVersion(&driver_version);
   set_int_aux("device::driver", driver_version);
+
+  set_string_aux("device::type", "gpu");
 
 #undef set_int_aux
 #undef set_string_aux


### PR DESCRIPTION
Since we are not using hipcc, the macros __HIP_PLATFORM_HCC__ and __HIP_PLATFORM_NVCC__ are not defined.