### PR TITLE
Document internal structs

### DIFF
--- a/backends/ispc.c
+++ b/backends/ispc.c
@@ -6,7 +6,7 @@ static const char *ERR_STR_ISPC_FAILURE =
     "ISPC %s failed with error message: %s.";
 
 /**
- * @ingroup nomp_types
+ * @ingroup nomp_structs
  *
  * @brief Represents a memory block that can be used for data storage and
  * transfer between a host and a device.
@@ -47,7 +47,7 @@ struct ispc_backend {
 };
 
 /**
- * @ingroup nomp_types
+ * @ingroup nomp_structs
  *
  * @brief Struct to store ISPC program information.
  */

--- a/backends/ispc.c
+++ b/backends/ispc.c
@@ -5,17 +5,64 @@
 static const char *ERR_STR_ISPC_FAILURE =
     "ISPC %s failed with error message: %s.";
 
+/**
+ * @ingroup nomp_types
+ *
+ * @brief Represents a memory block that can be used for data storage and
+ * transfer between a host and a device.
+ */
 struct ispc_backend {
-  char *ispc_cc, *cc, *ispc_flags, *cc_flags;
+  /**
+   * @brief Path to the ISPC compiler.
+   */
+  char *ispc_cc;
+  /**
+   * @brief Path to the C/C++ compiler.
+   */
+  char *cc;
+  /**
+   * @brief ISPC compiler flags.
+   */
+  char *ispc_flags;
+  /**
+   * @brief C/C++ compiler flags.
+   */
+  char *cc_flags;
+  /**
+   * @brief Handle to the selected device.
+   */
   ISPCRTDevice device;
+  /**
+   * @brief Type of device.
+   */
   ISPCRTDeviceType device_type;
+  /**
+   * @brief Handle to the task queue.
+   */
   ISPCRTTaskQueue queue;
+  /**
+   * @brief Flags to configure the creation of new memory views.
+   */
   ISPCRTNewMemoryViewFlags flags;
 };
 
+/**
+ * @ingroup nomp_types
+ *
+ * @brief Struct to store ISPC program information.
+ */
 struct ispc_prog {
+  /**
+   * @brief ID of the ISPC program.
+   */
   int ispc_id;
+  /**
+   * @brief Module of the ISPC program.
+   */
   ISPCRTModule module;
+  /**
+   * @brief Kernel of the ISPC program.
+   */
   ISPCRTKernel kernel;
 };
 

--- a/backends/opencl.c
+++ b/backends/opencl.c
@@ -18,14 +18,39 @@ static const char *ERR_STR_OPENCL_FAILURE = "%s failed with error code: %d.";
     }                                                                          \
   }
 
+/**
+ * @ingroup nomp_types
+ *
+ * @brief Struct to store OpenCL backend-specific data.
+ */
 struct opencl_backend_t {
+  /**
+   * @brief OpenCL device ID.
+   */
   cl_device_id device_id;
+  /**
+   * @brief OpenCL command queue.
+   */
   cl_command_queue queue;
+  /**
+   * @brief OpenCL context.
+   */
   cl_context ctx;
 };
 
+/**
+ * @ingroup nomp_types
+ *
+ * @brief Struct to store an OpenCL program and kernel.
+ */
 struct opencl_prog_t {
+  /**
+   * @brief OpenCL program.
+   */
   cl_program prg;
+  /**
+   * @brief OpenCL kernel.
+   */
   cl_kernel knl;
 };
 

--- a/backends/opencl.c
+++ b/backends/opencl.c
@@ -19,7 +19,7 @@ static const char *ERR_STR_OPENCL_FAILURE = "%s failed with error code: %d.";
   }
 
 /**
- * @ingroup nomp_types
+ * @ingroup nomp_structs
  *
  * @brief Struct to store OpenCL backend-specific data.
  */
@@ -39,7 +39,7 @@ struct opencl_backend_t {
 };
 
 /**
- * @ingroup nomp_types
+ * @ingroup nomp_structs
  *
  * @brief Struct to store an OpenCL program and kernel.
  */

--- a/backends/sycl.cpp
+++ b/backends/sycl.cpp
@@ -13,7 +13,7 @@ static const char *ERR_STR_SYCL_FAILURE = "SYCL backend failed with error: %s.";
   }
 
 /**
- * @ingroup nomp_types
+ * @ingroup nomp_structs
  *
  * @brief Struct to store SYCL backend specific data.
  */
@@ -41,7 +41,7 @@ struct sycl_backend {
 };
 
 /**
- * @ingroup nomp_types
+ * @ingroup nomp_structs
  *
  * @brief Struct to store SYCL program information.
  */

--- a/backends/sycl.cpp
+++ b/backends/sycl.cpp
@@ -12,14 +12,43 @@ static const char *ERR_STR_SYCL_FAILURE = "SYCL backend failed with error: %s.";
                     ex.what());                                                \
   }
 
+/**
+ * @ingroup nomp_types
+ *
+ * @brief Struct to store SYCL backend specific data.
+ */
 struct sycl_backend {
+  /**
+   * @brief SYCL device ID.
+   */
   sycl::device device_id;
+  /**
+   * @brief SYCL queue.
+   */
   sycl::queue queue;
+  /**
+   * @brief SYCL context.
+   */
   sycl::context ctx;
-  char *compiler, *compiler_flags;
+  /**
+   * @brief SYCL compiler path.
+   */
+  char *compiler;
+  /**
+   * @brief SYCL compiler flags.
+   */
+  char *compiler_flags;
 };
 
+/**
+ * @ingroup nomp_types
+ *
+ * @brief Struct to store SYCL program information.
+ */
 struct sycl_prog {
+  /**
+   * @brief ID of the SYCL program.
+   */
   int sycl_id;
 };
 

--- a/docs/user-api.rst
+++ b/docs/user-api.rst
@@ -20,6 +20,11 @@ Defines argument type.
    :project: libnomp
    :content-only:
 
+.. doxygengroup:: nomp_structs
+   :project: libnomp
+   :content-only:
+   :members:
+
 .. _group__nomp__errors:
 
 Errors

--- a/include/nomp-impl.h
+++ b/include/nomp-impl.h
@@ -30,7 +30,12 @@
 #include "nomp.h"
 
 /**
- * @ingroup nomp_types
+ * @defgroup nomp_structs C Structs
+ * @brief C structs used in libnomp
+ */
+
+/**
+ * @ingroup nomp_structs
  *
  * @brief Represents a memory block that can be used for data storage and
  * transfer between a host and a device.
@@ -66,7 +71,7 @@ struct nomp_mem_t {
 #define NOMP_MEM_BYTES(start, end, usize) (((end) - (start)) * (usize))
 
 /**
- * @ingroup nomp_types
+ * @ingroup nomp_structs
  *
  * @brief Represents a kernel argument.
  */
@@ -90,7 +95,7 @@ struct nomp_arg_t {
 };
 
 /**
- * @ingroup nomp_types
+ * @ingroup nomp_structs
  *
  * @brief Struct to store meta information about kernel arguments.
  */
@@ -164,7 +169,7 @@ struct nomp_prog_t {
 };
 
 /**
- * @ingroup nomp_types
+ * @ingroup nomp_structs
  *
  * @brief Struct to store user configurations and pointers to backend functions.
  */

--- a/src/jit.c
+++ b/src/jit.c
@@ -99,8 +99,19 @@ static int compile_aux(const char *cc, const char *cflags, const char *src,
   return err;
 }
 
+/**
+ * @ingroup nomp_types
+ *
+ * @brief Struct to store information about a dynamic loaded function.
+ */
 struct function {
+  /**
+   * @brief Handle to the dynamic library that contains the function.
+   */
   void *dlh;
+  /**
+   * @brief Pointer to the function.
+   */
   void (*dlf)(void **);
 };
 

--- a/src/jit.c
+++ b/src/jit.c
@@ -100,7 +100,7 @@ static int compile_aux(const char *cc, const char *cflags, const char *src,
 }
 
 /**
- * @ingroup nomp_types
+ * @ingroup nomp_structs
  *
  * @brief Struct to store information about a dynamic loaded function.
  */

--- a/src/log.c
+++ b/src/log.c
@@ -8,9 +8,23 @@ const char *ERR_STR_USER_MAP_PTR_IS_INVALID =
 const char *ERR_STR_USER_DEVICE_IS_INVALID =
     "Device id %d passed into libnomp is not valid.";
 
+/**
+ * @ingroup nomp_types
+ *
+ * @brief Struct to store information about a log entry.
+ */
 struct log {
+  /**
+   * @brief Description of the log entry.
+   */
   char *description;
+  /**
+   * @brief Log number associated with the entry.
+   */
   int logno;
+  /**
+   * @brief Type of log.
+   */
   nomp_log_type type;
 };
 

--- a/src/log.c
+++ b/src/log.c
@@ -9,7 +9,7 @@ const char *ERR_STR_USER_DEVICE_IS_INVALID =
     "Device id %d passed into libnomp is not valid.";
 
 /**
- * @ingroup nomp_types
+ * @ingroup nomp_structs
  *
  * @brief Struct to store information about a log entry.
  */


### PR DESCRIPTION
C structs are documented as in [Doxygen tests](https://github.com/doxygen/doxygen/blob/69342febd375499da5510f9dd09e379ea415e7b7/testing/100_a.c#L57). But for some unfound reason, the members of the struct is not being parsed when the docs are built. The output is as followed,
![image](https://github.com/nomp-org/libnomp/assets/62171036/9ddfb3dc-0f40-4101-8de8-6c6cf6cdeca4)
